### PR TITLE
Fix Clerk-backed JD/profile persistence and annotate PRD status

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ Thumbs.db
 .claude/settings.local.json
 
 /src/generated/prisma
+
+# clerk configuration (can include secrets)
+/.clerk/

--- a/app/api/job-descriptions/__tests__/route.test.ts
+++ b/app/api/job-descriptions/__tests__/route.test.ts
@@ -151,4 +151,21 @@ describe('GET /api/job-descriptions', () => {
     expect(body).toHaveLength(1);
     expect(body[0].id).toBe('jd-cuid-123');
   });
+
+  it('returns 422 when syncing the authenticated user fails', async () => {
+    mockAuth.mockResolvedValue(mockUser);
+    mockCurrentUser.mockResolvedValue({
+      primaryEmailAddress: null,
+      emailAddresses: [],
+    });
+
+    const res = await GET(new Request('http://localhost/api/job-descriptions'));
+    const body = await res.json();
+
+    expect(res.status).toBe(422);
+    expect(body).toEqual({
+      error: 'Authenticated user is missing a primary email address',
+    });
+    expect(mockGetAll).not.toHaveBeenCalled();
+  });
 });

--- a/app/api/job-descriptions/__tests__/route.test.ts
+++ b/app/api/job-descriptions/__tests__/route.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 vi.mock('@clerk/nextjs/server', () => ({
   auth: vi.fn(),
+  currentUser: vi.fn(),
 }));
 
 vi.mock('../../../../src/lib/jobDescription/parseJobDescription', () => ({
@@ -13,18 +14,25 @@ vi.mock('../../../../src/lib/jobDescription/jobDescriptionRepository', () => ({
   getJobDescriptionsByUser: vi.fn(),
 }));
 
-import { auth } from '@clerk/nextjs/server';
+vi.mock('../../../../src/lib/userRepository', () => ({
+  upsertUser: vi.fn(),
+}));
+
+import { auth, currentUser } from '@clerk/nextjs/server';
 import { parseJobDescription } from '../../../../src/lib/jobDescription/parseJobDescription';
 import {
   saveJobDescription,
   getJobDescriptionsByUser,
 } from '../../../../src/lib/jobDescription/jobDescriptionRepository';
+import { upsertUser } from '../../../../src/lib/userRepository';
 import { POST, GET } from '../route';
 
 const mockAuth = auth as unknown as ReturnType<typeof vi.fn>;
+const mockCurrentUser = currentUser as unknown as ReturnType<typeof vi.fn>;
 const mockParse = parseJobDescription as unknown as ReturnType<typeof vi.fn>;
 const mockSave = saveJobDescription as unknown as ReturnType<typeof vi.fn>;
 const mockGetAll = getJobDescriptionsByUser as unknown as ReturnType<typeof vi.fn>;
+const mockUpsertUser = upsertUser as unknown as ReturnType<typeof vi.fn>;
 
 const mockUser = { userId: 'user_clerk_abc', user: { id: 'user-db-cuid' } };
 
@@ -46,6 +54,11 @@ const mockSaved = {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  mockCurrentUser.mockResolvedValue({
+    primaryEmailAddress: { emailAddress: 'test@example.com' },
+    emailAddresses: [{ emailAddress: 'test@example.com' }],
+  });
+  mockUpsertUser.mockResolvedValue(undefined);
 });
 
 function makeRequest(body: unknown) {
@@ -73,6 +86,7 @@ describe('POST /api/job-descriptions', () => {
     const body = await res.json();
 
     expect(res.status).toBe(201);
+    expect(mockUpsertUser).toHaveBeenCalledWith('user_clerk_abc', 'test@example.com');
     expect(mockParse).toHaveBeenCalledWith('Senior Engineer role at Acme Corp.');
     expect(mockSave).toHaveBeenCalledWith('user_clerk_abc', mockParsed);
     expect(body.id).toBe('jd-cuid-123');
@@ -132,6 +146,7 @@ describe('GET /api/job-descriptions', () => {
     const body = await res.json();
 
     expect(res.status).toBe(200);
+    expect(mockUpsertUser).toHaveBeenCalledWith('user_clerk_abc', 'test@example.com');
     expect(mockGetAll).toHaveBeenCalledWith('user_clerk_abc');
     expect(body).toHaveLength(1);
     expect(body[0].id).toBe('jd-cuid-123');

--- a/app/api/job-descriptions/route.ts
+++ b/app/api/job-descriptions/route.ts
@@ -1,9 +1,21 @@
-import { auth } from '@clerk/nextjs/server';
+import { auth, currentUser } from '@clerk/nextjs/server';
 import { parseJobDescription } from '../../../src/lib/jobDescription/parseJobDescription';
 import {
   saveJobDescription,
   getJobDescriptionsByUser,
 } from '../../../src/lib/jobDescription/jobDescriptionRepository';
+import { upsertUser } from '../../../src/lib/userRepository';
+
+async function ensureCurrentUserRecord(clerkUserId: string): Promise<void> {
+  const user = await currentUser();
+  const primaryEmail = user?.primaryEmailAddress?.emailAddress ?? user?.emailAddresses?.[0]?.emailAddress;
+
+  if (!primaryEmail) {
+    throw new Error('Authenticated user is missing a primary email address');
+  }
+
+  await upsertUser(clerkUserId, primaryEmail);
+}
 
 export async function POST(request: Request) {
   const { userId } = await auth();
@@ -24,6 +36,7 @@ export async function POST(request: Request) {
   }
 
   try {
+    await ensureCurrentUserRecord(userId);
     const parsed = await parseJobDescription(input);
     const saved = await saveJobDescription(userId, parsed);
     return Response.json(saved, { status: 201 });
@@ -38,6 +51,7 @@ export async function GET(_request: Request) {
     return Response.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
+  await ensureCurrentUserRecord(userId);
   const jds = await getJobDescriptionsByUser(userId);
   return Response.json(jds, { status: 200 });
 }

--- a/app/api/job-descriptions/route.ts
+++ b/app/api/job-descriptions/route.ts
@@ -8,13 +8,18 @@ import { upsertUser } from '../../../src/lib/userRepository';
 
 async function ensureCurrentUserRecord(clerkUserId: string): Promise<void> {
   const user = await currentUser();
-  const primaryEmail = user?.primaryEmailAddress?.emailAddress ?? user?.emailAddresses?.[0]?.emailAddress;
+  const primaryEmail =
+    user?.primaryEmailAddress?.emailAddress ?? user?.emailAddresses?.[0]?.emailAddress;
 
   if (!primaryEmail) {
     throw new Error('Authenticated user is missing a primary email address');
   }
 
   await upsertUser(clerkUserId, primaryEmail);
+}
+
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : 'Unexpected error';
 }
 
 export async function POST(request: Request) {
@@ -41,7 +46,7 @@ export async function POST(request: Request) {
     const saved = await saveJobDescription(userId, parsed);
     return Response.json(saved, { status: 201 });
   } catch (err) {
-    return Response.json({ error: (err as Error).message }, { status: 422 });
+    return Response.json({ error: getErrorMessage(err) }, { status: 422 });
   }
 }
 
@@ -51,7 +56,11 @@ export async function GET(_request: Request) {
     return Response.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
-  await ensureCurrentUserRecord(userId);
-  const jds = await getJobDescriptionsByUser(userId);
-  return Response.json(jds, { status: 200 });
+  try {
+    await ensureCurrentUserRecord(userId);
+    const jds = await getJobDescriptionsByUser(userId);
+    return Response.json(jds, { status: 200 });
+  } catch (err) {
+    return Response.json({ error: getErrorMessage(err) }, { status: 422 });
+  }
 }

--- a/docs/PRD_Resume_Refine_AutoFill_Tool.md
+++ b/docs/PRD_Resume_Refine_AutoFill_Tool.md
@@ -8,6 +8,7 @@
 > Implementation review updated: 2026-04-16
 >
 > Status legend used below:
+>
 > - `Done` = implemented in the current codebase
 > - `Partial` = some foundation or UI/backend slice exists, but the feature is not complete end-to-end
 > - `Not Started` = no meaningful implementation found in the current codebase
@@ -265,35 +266,35 @@ Status: `Not Started`
 
 ### Phase Summary
 
-| Phase   | Status                         | What is actually implemented today                                                                 |
-| ------- | ------------------------------ | -------------------------------------------------------------------------------------------------- |
-| Phase 1 | `Partial`                      | Authenticated dashboard shell, job description intake UI/API, persistence layer, master profile backend |
-| Phase 2 | `Not Started`                  | No resume editor, inline comments, revision engine, diffing, or version history                    |
-| Phase 3 | `Not Started`                  | No browser automation, auto-fill adapters, screening-answer generation, or review-before-submit UI |
+| Phase   | Status        | What is actually implemented today                                                                      |
+| ------- | ------------- | ------------------------------------------------------------------------------------------------------- |
+| Phase 1 | `Partial`     | Authenticated dashboard shell, job description intake UI/API, persistence layer, master profile backend |
+| Phase 2 | `Not Started` | No resume editor, inline comments, revision engine, diffing, or version history                         |
+| Phase 3 | `Not Started` | No browser automation, auto-fill adapters, screening-answer generation, or review-before-submit UI      |
 
 ### Feature Checklist by PRD Requirement
 
-| Requirement | Status      | Notes |
-| ----------- | ----------- | ----- |
-| FR-1.1      | `Partial`   | Job description paste/URL intake exists; tailoring does not follow |
-| FR-1.2      | `Not Started` | No resume upload/template handling |
-| FR-1.3      | `Not Started` | No context extraction implementation |
-| FR-1.4      | `Not Started` | No tailored resume generation |
-| FR-1.5      | `Not Started` | No `.docx` output |
-| FR-1.6      | `Partial`   | Strong backend data model; no user-facing profile workflow |
-| FR-2.1      | `Not Started` | No editing interface |
-| FR-2.2      | `Not Started` | No inline comment system |
-| FR-2.3      | `Not Started` | No targeted AI revision |
-| FR-2.4      | `Not Started` | No iterative editing loop |
-| FR-2.5      | `Not Started` | No diff/highlight UI |
-| FR-2.6      | `Not Started` | No accept/reject controls |
-| FR-2.7      | `Not Started` | No version history |
-| FR-3.1      | `Not Started` | No browser integration |
-| FR-3.2      | `Not Started` | No field auto-fill |
-| FR-3.3      | `Not Started` | No Workday adapter |
-| FR-3.4      | `Not Started` | No screening answer generation |
-| FR-3.5      | `Not Started` | No user-review submission flow |
-| FR-3.6      | `Not Started` | No editable auto-fill review UI |
+| Requirement | Status        | Notes                                                              |
+| ----------- | ------------- | ------------------------------------------------------------------ |
+| FR-1.1      | `Partial`     | Job description paste/URL intake exists; tailoring does not follow |
+| FR-1.2      | `Not Started` | No resume upload/template handling                                 |
+| FR-1.3      | `Not Started` | No context extraction implementation                               |
+| FR-1.4      | `Not Started` | No tailored resume generation                                      |
+| FR-1.5      | `Not Started` | No `.docx` output                                                  |
+| FR-1.6      | `Partial`     | Strong backend data model; no user-facing profile workflow         |
+| FR-2.1      | `Not Started` | No editing interface                                               |
+| FR-2.2      | `Not Started` | No inline comment system                                           |
+| FR-2.3      | `Not Started` | No targeted AI revision                                            |
+| FR-2.4      | `Not Started` | No iterative editing loop                                          |
+| FR-2.5      | `Not Started` | No diff/highlight UI                                               |
+| FR-2.6      | `Not Started` | No accept/reject controls                                          |
+| FR-2.7      | `Not Started` | No version history                                                 |
+| FR-3.1      | `Not Started` | No browser integration                                             |
+| FR-3.2      | `Not Started` | No field auto-fill                                                 |
+| FR-3.3      | `Not Started` | No Workday adapter                                                 |
+| FR-3.4      | `Not Started` | No screening answer generation                                     |
+| FR-3.5      | `Not Started` | No user-review submission flow                                     |
+| FR-3.6      | `Not Started` | No editable auto-fill review UI                                    |
 
 ---
 

--- a/docs/PRD_Resume_Refine_AutoFill_Tool.md
+++ b/docs/PRD_Resume_Refine_AutoFill_Tool.md
@@ -5,6 +5,13 @@
 **Authors:** sunlipeipei, iDako7
 **Status:** Draft
 
+> Implementation review updated: 2026-04-16
+>
+> Status legend used below:
+> - `Done` = implemented in the current codebase
+> - `Partial` = some foundation or UI/backend slice exists, but the feature is not complete end-to-end
+> - `Not Started` = no meaningful implementation found in the current codebase
+
 ---
 
 ## 1. Introduction / Overview
@@ -42,45 +49,67 @@ This tool solves both problems by combining AI-powered resume tailoring with int
 ### Phase 1: AI-Powered Resume Tailoring Engine
 
 **FR-1.1:** The system must accept a job description as input (pasted text or URL).
+Status: `Partial`
+Notes: The app has a protected dashboard flow and a `New Project` page where users can paste text or enter a URL. The backend parses pasted text or fetches and parses URL content, then stores the job description in PostgreSQL. The flow stops after intake; no downstream resume generation exists yet.
 
 **FR-1.2:** The system must accept a user's existing resume as a style template. Supported input format: Word (.docx).
+Status: `Not Started`
+Notes: The data model includes `resumeTemplatePath`, but there is no upload UI, file handling, parsing, or validation for `.docx` templates.
 
 **FR-1.3:** The system must retrieve and parse context from user-specified sources:
+Status: `Not Started`
+Notes: No implemented GitHub/document ingestion pipeline was found. The PRD, architecture docs, and MCP setup mention this capability, but there is no shipped feature path for extracting project context into resume generation.
 
 - Code repositories (e.g., GitHub repos) — extract project names, technologies, README content, and commit history summaries.
 - Project documents (e.g., PRDs, design docs, meeting notes) — extract responsibilities, accomplishments, and technical details.
 
 **FR-1.4:** The system must generate a tailored resume that:
+Status: `Not Started`
+Notes: No Claude/Anthropic integration, resume synthesis pipeline, or structured resume generation logic was found.
 
 - Highlights skills and experiences relevant to the target job description.
 - Uses concrete, quantifiable facts drawn from the retrieved context (not generic filler).
 - Preserves the formatting style, tone, and structure of the user's template resume.
 
 **FR-1.5:** The system must output the tailored resume in Word (.docx) format.
+Status: `Not Started`
+Notes: The Prisma schema reserves a `Resume` model and `docxPath`, but there is no `.docx` generation or download flow.
 
 **FR-1.6:** The system must support a "master profile" — a comprehensive document containing all of the user's experiences, skills, and projects — which serves as the primary data source for tailoring.
+Status: `Partial`
+Notes: This is the most mature Phase 1 backend feature. The project contains a full TypeScript/Zod master profile model, merge logic, file-based profile manager, Prisma-backed profile repository, schema tests, and integration tests. However, there is no user-facing profile creation/editing UI yet.
 
 ### Phase 2: Interactive Editing Interface
 
 **FR-2.1:** The system must provide a web-based editing interface where users can view and edit their generated resume.
+Status: `Not Started`
+Notes: No resume editor page or generated resume viewer exists.
 
 **FR-2.2:** The system must allow users to select a specific section or line of text and attach a comment or instruction (e.g., "make this more concise," "add metrics," "remove this bullet").
+Status: `Not Started`
 
 **FR-2.3:** The AI must process inline comments and revise only the targeted section, leaving the rest of the document unchanged.
+Status: `Not Started`
 
 **FR-2.4:** The system must support multiple rounds of revision. Users can continue providing feedback and the AI will iteratively improve the document.
+Status: `Not Started`
 
 **FR-2.5:** The system must display a diff view or change highlights so users can see what the AI modified after each revision round.
+Status: `Not Started`
 
 **FR-2.6:** The system must allow users to accept, reject, or further modify each AI-suggested change.
+Status: `Not Started`
 
 **FR-2.7:** The system must maintain a version history so users can revert to any previous version.
+Status: `Not Started`
 
 ### Phase 3: Auto-Fill Application Forms
 
 **FR-3.1:** The system must integrate with web browsers (via a browser extension or MCP-based automation) to interact with job application portals.
+Status: `Not Started`
 
 **FR-3.2:** The system must auto-detect and fill standard form fields on supported platforms, including:
+Status: `Not Started`
 
 - Personal information (name, email, phone, address)
 - Work history (company, title, dates, descriptions)
@@ -89,16 +118,20 @@ This tool solves both problems by combining AI-powered resume tailoring with int
 - Upload resume file
 
 **FR-3.3:** The system must support Workday-based portals as the primary target. Support for other form-heavy portals (e.g., Taleo, iCIMS, custom ATS) is a secondary goal.
+Status: `Not Started`
 
 **FR-3.4:** The system must generate draft answers to common screening questions based on the user's profile and the specific job description. Examples include:
+Status: `Not Started`
 
 - "Why do you want to work here?"
 - "Describe your experience with [technology]."
 - "What is your expected salary range?"
 
 **FR-3.5:** The system must present all auto-filled content and generated answers for user review before final submission. The system must NOT submit any application without explicit user confirmation.
+Status: `Not Started`
 
 **FR-3.6:** The system must allow users to edit any auto-filled field or generated answer before submission.
+Status: `Not Started`
 
 ---
 
@@ -227,6 +260,40 @@ This tool solves both problems by combining AI-powered resume tailoring with int
 - [ ] Screening question answers are generated and presented for review.
 - [ ] No form is submitted without explicit user confirmation.
 - [ ] Auto-fill works on at least 3 different Workday-based employer portals.
+
+## 11.1 Implementation Status Summary
+
+### Phase Summary
+
+| Phase   | Status                         | What is actually implemented today                                                                 |
+| ------- | ------------------------------ | -------------------------------------------------------------------------------------------------- |
+| Phase 1 | `Partial`                      | Authenticated dashboard shell, job description intake UI/API, persistence layer, master profile backend |
+| Phase 2 | `Not Started`                  | No resume editor, inline comments, revision engine, diffing, or version history                    |
+| Phase 3 | `Not Started`                  | No browser automation, auto-fill adapters, screening-answer generation, or review-before-submit UI |
+
+### Feature Checklist by PRD Requirement
+
+| Requirement | Status      | Notes |
+| ----------- | ----------- | ----- |
+| FR-1.1      | `Partial`   | Job description paste/URL intake exists; tailoring does not follow |
+| FR-1.2      | `Not Started` | No resume upload/template handling |
+| FR-1.3      | `Not Started` | No context extraction implementation |
+| FR-1.4      | `Not Started` | No tailored resume generation |
+| FR-1.5      | `Not Started` | No `.docx` output |
+| FR-1.6      | `Partial`   | Strong backend data model; no user-facing profile workflow |
+| FR-2.1      | `Not Started` | No editing interface |
+| FR-2.2      | `Not Started` | No inline comment system |
+| FR-2.3      | `Not Started` | No targeted AI revision |
+| FR-2.4      | `Not Started` | No iterative editing loop |
+| FR-2.5      | `Not Started` | No diff/highlight UI |
+| FR-2.6      | `Not Started` | No accept/reject controls |
+| FR-2.7      | `Not Started` | No version history |
+| FR-3.1      | `Not Started` | No browser integration |
+| FR-3.2      | `Not Started` | No field auto-fill |
+| FR-3.3      | `Not Started` | No Workday adapter |
+| FR-3.4      | `Not Started` | No screening answer generation |
+| FR-3.5      | `Not Started` | No user-review submission flow |
+| FR-3.6      | `Not Started` | No editable auto-fill review UI |
 
 ---
 

--- a/src/lib/__tests__/profileRepository.test.ts
+++ b/src/lib/__tests__/profileRepository.test.ts
@@ -6,6 +6,9 @@ import type { MasterProfile } from '../../profile/types';
 // Mock the Prisma singleton so tests never hit a real DB
 vi.mock('../prisma', () => ({
   prisma: {
+    user: {
+      findUnique: vi.fn(),
+    },
     profile: {
       findUnique: vi.fn(),
       upsert: vi.fn(),
@@ -18,6 +21,7 @@ import { prisma } from '../prisma';
 
 const mockFindUnique = vi.mocked(prisma.profile.findUnique);
 const mockUpsert = vi.mocked(prisma.profile.upsert);
+const mockFindUser = vi.mocked(prisma.user.findUnique);
 
 const validProfile: MasterProfile = {
   schemaVersion: 1,
@@ -29,9 +33,20 @@ const validProfile: MasterProfile = {
   education: [],
 };
 
+function makeDbUser(clerkId: string) {
+  return {
+    id: `db-${clerkId}`,
+    clerkId,
+    email: 'jane@example.com',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  } as never;
+}
+
 describe('getProfile', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockFindUser.mockImplementation(async ({ where: { clerkId } }: any) => makeDbUser(clerkId));
   });
 
   it('returns null when no profile record exists', async () => {
@@ -40,13 +55,13 @@ describe('getProfile', () => {
     const result = await getProfile('user-123');
 
     expect(result).toBeNull();
-    expect(mockFindUnique).toHaveBeenCalledWith({ where: { userId: 'user-123' } });
+    expect(mockFindUnique).toHaveBeenCalledWith({ where: { userId: 'db-user-123' } });
   });
 
   it('returns parsed MasterProfile when record exists', async () => {
     mockFindUnique.mockResolvedValue({
       id: 'profile-1',
-      userId: 'user-123',
+      userId: 'db-user-123',
       data: validProfile,
       createdAt: new Date(),
       updatedAt: new Date(),
@@ -60,7 +75,7 @@ describe('getProfile', () => {
   it('throws ProfileValidationError when stored data is invalid', async () => {
     mockFindUnique.mockResolvedValue({
       id: 'profile-1',
-      userId: 'user-123',
+      userId: 'db-user-123',
       data: { name: 'No Email' }, // missing required fields
       createdAt: new Date(),
       updatedAt: new Date(),
@@ -73,6 +88,7 @@ describe('getProfile', () => {
 describe('saveProfile', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockFindUser.mockImplementation(async ({ where: { clerkId } }: any) => makeDbUser(clerkId));
     mockUpsert.mockResolvedValue({} as never);
   });
 
@@ -80,8 +96,8 @@ describe('saveProfile', () => {
     await saveProfile('user-123', validProfile);
 
     expect(mockUpsert).toHaveBeenCalledWith({
-      where: { userId: 'user-123' },
-      create: { userId: 'user-123', data: expect.objectContaining({ name: 'Jane Doe' }) },
+      where: { userId: 'db-user-123' },
+      create: { userId: 'db-user-123', data: expect.objectContaining({ name: 'Jane Doe' }) },
       update: { data: expect.objectContaining({ name: 'Jane Doe' }) },
     });
   });
@@ -107,9 +123,15 @@ describe('saveProfile', () => {
     expect(mockUpsert).toHaveBeenCalledTimes(2);
     expect(mockUpsert).toHaveBeenLastCalledWith(
       expect.objectContaining({
-        where: { userId: 'user-456' },
+        where: { userId: 'db-user-456' },
         update: { data: expect.objectContaining({ name: 'Jane Updated' }) },
       })
     );
+  });
+
+  it('throws when the Clerk user does not exist in the app database', async () => {
+    mockFindUser.mockResolvedValue(null);
+
+    await expect(getProfile('missing-user')).rejects.toThrow('User record not found');
   });
 });

--- a/src/lib/__tests__/profileRepository.test.ts
+++ b/src/lib/__tests__/profileRepository.test.ts
@@ -46,7 +46,8 @@ function makeDbUser(clerkId: string) {
 describe('getProfile', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockFindUser.mockImplementation(async ({ where: { clerkId } }: any) => makeDbUser(clerkId));
+    mockFindUser.mockImplementation(((args: { where: { clerkId: string } }) =>
+      Promise.resolve(makeDbUser(args.where.clerkId))) as never);
   });
 
   it('returns null when no profile record exists', async () => {
@@ -88,7 +89,8 @@ describe('getProfile', () => {
 describe('saveProfile', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockFindUser.mockImplementation(async ({ where: { clerkId } }: any) => makeDbUser(clerkId));
+    mockFindUser.mockImplementation(((args: { where: { clerkId: string } }) =>
+      Promise.resolve(makeDbUser(args.where.clerkId))) as never);
     mockUpsert.mockResolvedValue({} as never);
   });
 

--- a/src/lib/jobDescription/__tests__/jobDescriptionRepository.test.ts
+++ b/src/lib/jobDescription/__tests__/jobDescriptionRepository.test.ts
@@ -2,6 +2,9 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 vi.mock('../../prisma', () => ({
   prisma: {
+    user: {
+      findUnique: vi.fn(),
+    },
     jobDescription: {
       create: vi.fn(),
       findMany: vi.fn(),
@@ -20,6 +23,9 @@ import {
 import { prisma } from '../../prisma';
 
 const mockPrisma = prisma as unknown as {
+  user: {
+    findUnique: ReturnType<typeof vi.fn>;
+  };
   jobDescription: {
     create: ReturnType<typeof vi.fn>;
     findMany: ReturnType<typeof vi.fn>;
@@ -41,6 +47,11 @@ const mockJd = {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  mockPrisma.user.findUnique.mockResolvedValue({
+    id: 'user-cuid-abc',
+    clerkId: 'user-clerk-abc',
+    email: 'test@example.com',
+  });
 });
 
 describe('saveJobDescription', () => {
@@ -107,6 +118,12 @@ describe('getJobDescriptionsByUser', () => {
 
     const result = await getJobDescriptionsByUser('user-cuid-abc');
     expect(result).toEqual([]);
+  });
+
+  it('throws when no internal user matches the Clerk user id', async () => {
+    mockPrisma.user.findUnique.mockResolvedValue(null);
+
+    await expect(getJobDescriptionsByUser('missing-user')).rejects.toThrow('User record not found');
   });
 });
 

--- a/src/lib/jobDescription/jobDescriptionRepository.ts
+++ b/src/lib/jobDescription/jobDescriptionRepository.ts
@@ -1,8 +1,20 @@
 import { prisma } from '../prisma';
+import { getUserByClerkId } from '../userRepository';
 import type { ParsedJobDescription } from './types';
 
-export async function saveJobDescription(userId: string, jd: ParsedJobDescription) {
-  if (!userId) throw new Error('userId is required');
+async function requireInternalUserId(clerkUserId: string): Promise<string> {
+  if (!clerkUserId) throw new Error('userId is required');
+
+  const user = await getUserByClerkId(clerkUserId);
+  if (!user) {
+    throw new Error('User record not found');
+  }
+
+  return user.id;
+}
+
+export async function saveJobDescription(clerkUserId: string, jd: ParsedJobDescription) {
+  const userId = await requireInternalUserId(clerkUserId);
 
   return prisma.jobDescription.create({
     data: {
@@ -13,20 +25,25 @@ export async function saveJobDescription(userId: string, jd: ParsedJobDescriptio
   });
 }
 
-export async function getJobDescriptionsByUser(userId: string) {
+export async function getJobDescriptionsByUser(clerkUserId: string) {
+  const userId = await requireInternalUserId(clerkUserId);
+
   return prisma.jobDescription.findMany({
     where: { userId },
     orderBy: { createdAt: 'desc' },
   });
 }
 
-export async function getJobDescriptionById(id: string, userId: string) {
+export async function getJobDescriptionById(id: string, clerkUserId: string) {
+  const userId = await requireInternalUserId(clerkUserId);
+
   return prisma.jobDescription.findFirst({
     where: { id, userId },
   });
 }
 
-export async function deleteJobDescription(id: string, userId: string) {
+export async function deleteJobDescription(id: string, clerkUserId: string) {
+  const userId = await requireInternalUserId(clerkUserId);
   const existing = await prisma.jobDescription.findFirst({ where: { id, userId } });
   if (!existing) throw new Error('Not found');
 

--- a/src/lib/profileRepository.ts
+++ b/src/lib/profileRepository.ts
@@ -2,12 +2,25 @@ import { prisma } from './prisma';
 import { MasterProfileSchema } from '../profile/schema';
 import { MasterProfile } from '../profile/types';
 import { ProfileValidationError } from '../profile/errors';
+import { getUserByClerkId } from './userRepository';
+
+async function requireInternalUserId(clerkUserId: string): Promise<string> {
+  if (!clerkUserId) throw new Error('userId is required');
+
+  const user = await getUserByClerkId(clerkUserId);
+  if (!user) {
+    throw new Error('User record not found');
+  }
+
+  return user.id;
+}
 
 /**
  * Load the authenticated user's profile from the database.
  * Returns null if no profile exists yet.
  */
-export async function getProfile(userId: string): Promise<MasterProfile | null> {
+export async function getProfile(clerkUserId: string): Promise<MasterProfile | null> {
+  const userId = await requireInternalUserId(clerkUserId);
   const record = await prisma.profile.findUnique({ where: { userId } });
   if (!record) return null;
 
@@ -21,7 +34,8 @@ export async function getProfile(userId: string): Promise<MasterProfile | null> 
 /**
  * Upsert the authenticated user's profile in the database.
  */
-export async function saveProfile(userId: string, profile: MasterProfile): Promise<void> {
+export async function saveProfile(clerkUserId: string, profile: MasterProfile): Promise<void> {
+  const userId = await requireInternalUserId(clerkUserId);
   const result = MasterProfileSchema.safeParse(profile);
   if (!result.success) {
     throw new ProfileValidationError(result.error);


### PR DESCRIPTION
## Summary
This PR contains two focused commits:

1. `fix: map Clerk users to app records for JD/profile access`
   - ensure the job-description API upserts the authenticated Clerk user into the app database before reads/writes
   - translate Clerk `userId` values to internal Prisma `User.id` values in the job-description and profile repositories
   - update repository and route tests to cover the new behavior

2. `docs: annotate PRD implementation status`
   - add an implementation review to the PRD
   - mark each PRD feature as `Done`, `Partial`, or `Not Started`
   - summarize the actual status of Phases 1, 2, and 3 against the current codebase

## Verification
- `npm test`
- `npm run db:push`

## Notes
- local dev servers were stopped before publishing this branch
- the PRD status annotations reflect the current repository implementation, not the planned scope
