### PR TITLE
chore: add husky pre-push hook (format:check + tsc --noEmit)

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,2 @@
+npm run format:check
+npx tsc --noEmit

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
         "autoprefixer": "^10.4.27",
         "eslint": "^9.39.4",
         "eslint-config-next": "^16.2.2",
+        "husky": "^9.1.7",
         "jsdom": "^29.0.2",
         "postcss": "^8.5.8",
         "prettier": "^3.8.1",
@@ -7971,6 +7972,22 @@
       "integrity": "sha512-RJ8XvFvpPM/Dmc5SV+dC4y5PCeOhT3x1Hq0NU3rjGeg5a/CqlhZ7uudknPwZFz4aeAXDcbAyaeP7GAo9lvngtA==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
+      }
     },
     "node_modules/hyphen": {
       "version": "1.14.1",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "db:push": "prisma db push",
     "db:studio": "prisma studio",
     "format": "prettier --write .",
-    "format:check": "prettier --check ."
+    "format:check": "prettier --check .",
+    "prepare": "husky"
   },
   "devDependencies": {
     "@playwright/test": "^1.59.1",
@@ -35,6 +36,7 @@
     "autoprefixer": "^10.4.27",
     "eslint": "^9.39.4",
     "eslint-config-next": "^16.2.2",
+    "husky": "^9.1.7",
     "jsdom": "^29.0.2",
     "postcss": "^8.5.8",
     "prettier": "^3.8.1",


### PR DESCRIPTION
## Summary

- Adds `husky` devDependency and a `.husky/pre-push` hook that runs `npm run format:check` and `npx tsc --noEmit` locally before every `git push`.
- Wires `prepare: \"husky\"` in `package.json` so the hook auto-installs on `npm install` for every teammate — no manual setup.

## Why

PR #56 burned four CI runs in ~40 minutes because partial commits (unformatted files, missing deps, missing tsconfig alias) kept reaching GitHub and failing CI there instead of locally. This hook catches the same class of failures on the dev's laptop in ~3.5s combined (format:check ~1.2s + tsc --noEmit ~2.2s), before `git push` ever hits the network.

### Scope picked deliberately

- **Included:** Prettier + TypeScript — the two gates that kept tripping on PR #56.
- **Excluded:** `npm run lint` (redundant with Prettier + tsc for the failures we saw; adds 3–5s), `npm test` (too slow for pre-push, CI already gates it).

### Bypass

- Emergency only: `HUSKY=0 git push` or `git push --no-verify`.

## Test plan

- [x] `npm install` installs husky and runs `husky` prepare — hook file present, executable.
- [x] `git push --dry-run` on a branch with unformatted files exits non-zero with `husky - pre-push script failed (code 1)`.
- [x] `git push --dry-run` on this branch (clean against main) passes: `All matched files use Prettier code style!`.
- [ ] Teammate pulls main, runs `npm install`, and confirms `.husky/pre-push` exists and fires on next push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)