### PR TITLE
[Phase-1.D] PDF export — React-PDF template, GET /api/resumes/[id]/pdf

### DIFF
--- a/app/(app)/tailor/[resumeId]/page.test.tsx
+++ b/app/(app)/tailor/[resumeId]/page.test.tsx
@@ -164,37 +164,38 @@ describe('TailorPage', () => {
 
   // ── PDF render stub ──────────────────────────────────────────────────────────
 
-  it('PDF Render button logs and shows transient status on click', async () => {
+  it('PDF Render button opens /api/resumes/[id]/pdf in a new tab and shows status', async () => {
     const user = userEvent.setup();
-    const consoleSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
+    const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
     setupMocksWithResume();
     await renderAndWaitForEditor();
 
     await user.click(screen.getByRole('button', { name: /render pdf/i }));
 
-    expect(consoleSpy).toHaveBeenCalledWith('[B2] PDF render requested', { resumeId: RESUME_ID });
-    expect(screen.getByText(/pdf render requested/i)).toBeInTheDocument();
+    expect(openSpy).toHaveBeenCalledWith(
+      `/api/resumes/${RESUME_ID}/pdf`,
+      '_blank',
+      'noopener,noreferrer'
+    );
+    expect(screen.getByText(/pdf download started/i)).toBeInTheDocument();
 
-    consoleSpy.mockRestore();
+    openSpy.mockRestore();
   });
 
   it('transient PDF status disappears after 2s', async () => {
     vi.useFakeTimers({ shouldAdvanceTime: true });
     const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime.bind(vi) });
-    const consoleSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
+    const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
 
     setupMocksWithResume();
 
-    // With fake timers, use real timers for the initial render only
     render(<TailorPage params={Promise.resolve({ resumeId: RESUME_ID })} />);
 
-    // Wait for editor by advancing real microtasks
     await vi.runAllTimersAsync();
-
     await screen.findByLabelText(/summary/i, {}, { timeout: 3000 });
 
     await user.click(screen.getByRole('button', { name: /render pdf/i }));
-    expect(screen.getByText(/pdf render requested/i)).toBeInTheDocument();
+    expect(screen.getByText(/pdf download started/i)).toBeInTheDocument();
 
     // Advance 2s to clear the transient status
     act(() => {
@@ -202,10 +203,10 @@ describe('TailorPage', () => {
     });
 
     await waitFor(() => {
-      expect(screen.queryByText(/pdf render requested/i)).not.toBeInTheDocument();
+      expect(screen.queryByText(/pdf download started/i)).not.toBeInTheDocument();
     });
 
-    consoleSpy.mockRestore();
+    openSpy.mockRestore();
     vi.useRealTimers();
   });
 

--- a/app/(app)/tailor/[resumeId]/page.tsx
+++ b/app/(app)/tailor/[resumeId]/page.tsx
@@ -109,8 +109,13 @@ export default function TailorPage({ params }: PageProps) {
   // ── Handlers ───────────────────────────────────────────────────────────────
 
   function handlePdfRender() {
-    console.info('[B2] PDF render requested', { resumeId: resumeId ?? '' });
-    showStatus('PDF render requested');
+    if (!resumeId) return;
+    const url = `/api/resumes/${encodeURIComponent(resumeId)}/pdf`;
+    // Open in a new tab so the browser triggers the download prompt without
+    // navigating away from the editor. The route sends Content-Disposition:
+    // attachment so most browsers will save rather than preview inline.
+    window.open(url, '_blank', 'noopener,noreferrer');
+    showStatus('PDF download started');
   }
 
   async function handleRefineSubmit() {

--- a/app/api/resumes/[resumeId]/pdf/route.test.ts
+++ b/app/api/resumes/[resumeId]/pdf/route.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../../../../src/lib/auth', () => ({
+  getAuth: vi.fn(),
+}));
+vi.mock('../../../../../src/lib/resumeRepository', () => ({
+  getResume: vi.fn(),
+}));
+vi.mock('../../../../../src/pdf/render', () => ({
+  renderResumeToPdf: vi.fn(),
+}));
+
+import { getAuth } from '../../../../../src/lib/auth';
+import { getResume } from '../../../../../src/lib/resumeRepository';
+import { renderResumeToPdf } from '../../../../../src/pdf/render';
+import { resumesFixture } from '../../../../../src/fixtures/index';
+import { GET } from './route';
+
+const mockAuth = getAuth as unknown as ReturnType<typeof vi.fn>;
+const mockGet = getResume as unknown as ReturnType<typeof vi.fn>;
+const mockRender = renderResumeToPdf as unknown as ReturnType<typeof vi.fn>;
+
+const RESUME = resumesFixture[0];
+
+function paramsFor(id: string): { params: Promise<{ resumeId: string }> } {
+  return { params: Promise.resolve({ resumeId: id }) };
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('GET /api/resumes/[resumeId]/pdf', () => {
+  it('returns 401 without a session', async () => {
+    mockAuth.mockResolvedValue({ userId: null });
+    const res = await GET(
+      new Request(`http://localhost/api/resumes/${RESUME.resumeId}/pdf`),
+      paramsFor(RESUME.resumeId)
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 404 when resume not found (cross-user or missing)', async () => {
+    mockAuth.mockResolvedValue({ userId: 'user-1' });
+    mockGet.mockResolvedValue(null);
+    const res = await GET(
+      new Request(`http://localhost/api/resumes/${RESUME.resumeId}/pdf`),
+      paramsFor(RESUME.resumeId)
+    );
+    expect(res.status).toBe(404);
+    expect(mockGet).toHaveBeenCalledWith(RESUME.resumeId, 'user-1');
+    expect(mockRender).not.toHaveBeenCalled();
+  });
+
+  it('returns 500 on render failure (internals logged, not leaked)', async () => {
+    mockAuth.mockResolvedValue({ userId: 'user-1' });
+    mockGet.mockResolvedValue(RESUME);
+    mockRender.mockRejectedValue(new Error('font not found at /private/path'));
+    const res = await GET(
+      new Request(`http://localhost/api/resumes/${RESUME.resumeId}/pdf`),
+      paramsFor(RESUME.resumeId)
+    );
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe('Failed to render PDF');
+    expect(body.error).not.toMatch(/font|path|private/);
+  });
+
+  it('returns a 200 application/pdf attachment on success', async () => {
+    const fakeBytes = new Uint8Array([0x25, 0x50, 0x44, 0x46, 0x2d, 0x31, 0x2e, 0x34, 0x0a]);
+    mockAuth.mockResolvedValue({ userId: 'user-1' });
+    mockGet.mockResolvedValue(RESUME);
+    mockRender.mockResolvedValue(fakeBytes);
+
+    const res = await GET(
+      new Request(`http://localhost/api/resumes/${RESUME.resumeId}/pdf`),
+      paramsFor(RESUME.resumeId)
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toBe('application/pdf');
+    expect(res.headers.get('content-disposition')).toMatch(/attachment; filename="resume-/);
+    expect(res.headers.get('cache-control')).toBe('no-store');
+
+    const buf = new Uint8Array(await res.arrayBuffer());
+    expect(buf.byteLength).toBe(fakeBytes.byteLength);
+    const head = Buffer.from(buf.slice(0, 5)).toString('ascii');
+    expect(head).toBe('%PDF-');
+  });
+});

--- a/app/api/resumes/[resumeId]/pdf/route.ts
+++ b/app/api/resumes/[resumeId]/pdf/route.ts
@@ -1,0 +1,48 @@
+import { getAuth } from '../../../../../src/lib/auth';
+import { getResume } from '../../../../../src/lib/resumeRepository';
+import { renderResumeToPdf } from '../../../../../src/pdf/render';
+
+export const runtime = 'nodejs';
+export const maxDuration = 30;
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ resumeId: string }> }
+): Promise<Response> {
+  let userId: string | null;
+  try {
+    ({ userId } = await getAuth());
+  } catch {
+    return Response.json({ error: 'Authentication error' }, { status: 500 });
+  }
+  if (!userId) {
+    return Response.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const { resumeId } = await params;
+  if (!resumeId) {
+    return Response.json({ error: 'Invalid resume id' }, { status: 400 });
+  }
+
+  const resume = await getResume(resumeId, userId);
+  if (!resume) {
+    return Response.json({ error: 'Resume not found' }, { status: 404 });
+  }
+
+  try {
+    const bytes = await renderResumeToPdf(resume);
+    return new Response(new Uint8Array(bytes), {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/pdf',
+        'Content-Disposition': `attachment; filename="resume-${resumeId}.pdf"`,
+        'Content-Length': String(bytes.byteLength),
+        'Cache-Control': 'no-store',
+      },
+    });
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    console.error('[api.pdf]', detail);
+    return Response.json({ error: 'Failed to render PDF' }, { status: 500 });
+  }
+}

--- a/src/pdf/ResumeTemplate.tsx
+++ b/src/pdf/ResumeTemplate.tsx
@@ -1,0 +1,139 @@
+import { Document, Page, Text, View, StyleSheet } from '@react-pdf/renderer';
+import type { TailoredResume } from '../ai/schemas';
+
+// Order matches ResumeSectionEnum so iteration stays stable.
+const SECTIONS = ['header', 'summary', 'skills', 'experience', 'education', 'projects'] as const;
+type SectionKey = (typeof SECTIONS)[number];
+
+const styles = StyleSheet.create({
+  page: {
+    padding: 36,
+    fontFamily: 'Helvetica',
+    fontSize: 10,
+    color: '#0f172a',
+  },
+  section: {
+    marginBottom: 14,
+  },
+  sectionHeading: {
+    fontSize: 11,
+    fontFamily: 'Helvetica-Bold',
+    textTransform: 'uppercase',
+    letterSpacing: 1.2,
+    color: '#64748b',
+    marginBottom: 6,
+  },
+  heading1: {
+    fontSize: 18,
+    fontFamily: 'Helvetica-Bold',
+    marginBottom: 4,
+  },
+  heading2: {
+    fontSize: 12,
+    fontFamily: 'Helvetica-Bold',
+    marginTop: 8,
+    marginBottom: 4,
+  },
+  paragraph: {
+    lineHeight: 1.4,
+    marginBottom: 4,
+  },
+  bullet: {
+    flexDirection: 'row',
+    marginBottom: 2,
+  },
+  bulletMark: {
+    width: 10,
+  },
+  bulletText: {
+    flex: 1,
+    lineHeight: 1.35,
+  },
+});
+
+function humanLabel(section: SectionKey): string {
+  return section.charAt(0).toUpperCase() + section.slice(1);
+}
+
+/**
+ * Minimal markdown-ish renderer. Handles the three constructs the tailor
+ * prompt produces: `# heading`, `## subheading`, `- bullet`. Anything
+ * else renders as a plain paragraph. This is intentionally simple — we
+ * are not a full markdown AST.
+ */
+function renderMarkdownBlock(markdown: string, keyPrefix: string) {
+  const lines = markdown.split('\n');
+  const nodes: React.ReactNode[] = [];
+  let buffer: string[] = [];
+
+  const flushParagraph = () => {
+    if (buffer.length === 0) return;
+    const text = buffer.join(' ').trim();
+    buffer = [];
+    if (!text) return;
+    nodes.push(
+      <Text key={`${keyPrefix}-p-${nodes.length}`} style={styles.paragraph}>
+        {text}
+      </Text>
+    );
+  };
+
+  lines.forEach((raw, i) => {
+    const line = raw.replace(/\s+$/, '');
+    if (line.trim().length === 0) {
+      flushParagraph();
+      return;
+    }
+    if (line.startsWith('# ')) {
+      flushParagraph();
+      nodes.push(
+        <Text key={`${keyPrefix}-h1-${i}`} style={styles.heading1}>
+          {line.slice(2).trim()}
+        </Text>
+      );
+    } else if (line.startsWith('## ')) {
+      flushParagraph();
+      nodes.push(
+        <Text key={`${keyPrefix}-h2-${i}`} style={styles.heading2}>
+          {line.slice(3).trim()}
+        </Text>
+      );
+    } else if (line.startsWith('- ') || line.startsWith('* ')) {
+      flushParagraph();
+      nodes.push(
+        <View key={`${keyPrefix}-b-${i}`} style={styles.bullet}>
+          <Text style={styles.bulletMark}>•</Text>
+          <Text style={styles.bulletText}>{line.slice(2).trim()}</Text>
+        </View>
+      );
+    } else {
+      buffer.push(line.trim());
+    }
+  });
+  flushParagraph();
+
+  return nodes;
+}
+
+interface Props {
+  resume: TailoredResume;
+}
+
+export function ResumeTemplate({ resume }: Props) {
+  return (
+    <Document>
+      <Page size="A4" style={styles.page}>
+        {SECTIONS.map((section) => {
+          const markdown = resume[section];
+          if (!markdown || markdown.trim().length === 0) return null;
+          return (
+            <View key={section} style={styles.section}>
+              <Text style={styles.sectionHeading}>{humanLabel(section)}</Text>
+              {renderMarkdownBlock(markdown, section)}
+            </View>
+          );
+        })}
+      </Page>
+    </Document>
+  );
+}

--- a/src/pdf/__tests__/render.test.ts
+++ b/src/pdf/__tests__/render.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { renderResumeToPdf } from '../render';
+import { resumesFixture } from '../../fixtures/index';
+
+describe('renderResumeToPdf', () => {
+  it('returns a Uint8Array starting with %PDF-', async () => {
+    const bytes = await renderResumeToPdf(resumesFixture[0]);
+    expect(bytes).toBeInstanceOf(Uint8Array);
+    expect(bytes.byteLength).toBeGreaterThan(1024);
+
+    const head = Buffer.from(bytes.slice(0, 5)).toString('ascii');
+    expect(head).toBe('%PDF-');
+  });
+
+  it('renders a larger buffer for a longer resume', async () => {
+    const small = await renderResumeToPdf({
+      ...resumesFixture[0],
+      summary: '## Summary\nOne line.',
+      skills: '## Skills\nTS.',
+      experience: '## Experience\n- one',
+      education: '## Education\n- one',
+      projects: '## Projects\n- one',
+    });
+    const big = await renderResumeToPdf(resumesFixture[0]);
+    expect(big.byteLength).toBeGreaterThan(small.byteLength);
+  });
+
+  it('handles empty string sections gracefully (no throw)', async () => {
+    const bytes = await renderResumeToPdf({
+      ...resumesFixture[0],
+      projects: '',
+    });
+    expect(bytes.byteLength).toBeGreaterThan(0);
+  });
+});

--- a/src/pdf/render.tsx
+++ b/src/pdf/render.tsx
@@ -1,0 +1,14 @@
+import { renderToBuffer } from '@react-pdf/renderer';
+import { ResumeTemplate } from './ResumeTemplate';
+import type { TailoredResume } from '../ai/schemas';
+
+/**
+ * Server-side render a TailoredResume into PDF bytes. Intended to be
+ * called from a route handler that streams the result; we return a
+ * Uint8Array so the caller can wrap it in a Response without Buffer-
+ * specific APIs leaking into the edge runtime later.
+ */
+export async function renderResumeToPdf(resume: TailoredResume): Promise<Uint8Array> {
+  const buf = await renderToBuffer(<ResumeTemplate resume={resume} />);
+  return new Uint8Array(buf);
+}


### PR DESCRIPTION
## Base branch

Stacked PR — base is `phase-1/c-refine` (PR #61). GitHub retargets on merge.

## Summary

- Server-side PDF render with `@react-pdf/renderer`; one-column A4 layout covering all six sections (`header`, `summary`, `skills`, `experience`, `education`, `projects`).
- `GET /api/resumes/[resumeId]/pdf` streams `application/pdf` with `Content-Disposition: attachment` so browsers save rather than preview inline. Auth + ownership scoped to the session user.
- Tailor page's **Render PDF** button now opens the endpoint in a new tab (`noopener,noreferrer`) and shows a transient status.

## Test plan

- [x] `npm test` — 41 files / 444 tests. New: render unit test (3), PDF route test (4). Updated: tailor page test for the new window.open flow.
- [x] `npx tsc --noEmit`, `npm run build`, `npm run lint`, `npm run format:check` — all green.
- [x] Render unit test asserts `%PDF-` header on the fixture, >1 KB output, proportional growth.
- [ ] Smoke: click Render PDF on the tailor page; verify the file downloads and opens in macOS Preview. *(Deferred — tomorrow with Dako.)*

## Security

- A01: `getResume(id, userId)` gates the render. Cross-user id → 404 (no distinction from missing).
- A09: render failure returns a fixed `Failed to render PDF` string; underlying error (which could name fonts/paths) stays in server logs.
- `Cache-Control: no-store` prevents intermediary caches from serving another user's PDF.

## AI disclosure

- Tooling: Claude Code (Opus 4.7, 1M context)
- AI-generated share: ~85% of the diff; human reviewed all edits before commit.

closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)