### PR TITLE
ci(s2-1): advisory AI PR review via claude-code-action@v1 (closes #24)

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,86 @@
+# BypassHire — AI PR Review (advisory)
+#
+# Stage 6 of the 8-stage CI/CD pipeline. Runs `anthropics/claude-code-action@v1`
+# on every PR to post a C.L.E.A.R.-framework review + security DoD check as a
+# PR comment. Advisory — never blocks merge (continue-on-error: true).
+#
+# Auth: CLAUDE_CODE_OAUTH_TOKEN (from `claude setup-token` — draws on the
+# Claude Code subscription; no per-PR API billing).
+#
+# Kept as a standalone workflow file (rather than a job in ci.yml) so a
+# Claude API outage can't perturb the build-stage dependency graph.
+
+name: Claude AI PR Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  claude-review:
+    name: AI PR Review (advisory)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            You are reviewing a pull request for **BypassHire** — a Next.js +
+            Prisma + Clerk + Claude API application. Project conventions are
+            in `CLAUDE.md`, `docs/security.md`, `docs/architecture.md`, and
+            `docs/testing-strategy.md` at the repo root. The PR branch is
+            already checked out in the working directory.
+
+            ## C.L.E.A.R. review (always apply)
+
+            Evaluate against the five dimensions. Call out any that fall short:
+            - **C**oncise — PR focused on one concern; no unrelated drive-by edits
+            - **L**inked — references a GitHub issue or spec section
+            - **E**xplicit — all acceptance criteria in the PR body are checked off
+            - **A**ctionable — comments tell the author where to start reading
+            - **R**eviewable — diff under ~400 lines (flag larger diffs without an explanation)
+
+            ## Security review (reference docs/security.md — OWASP Top 10)
+
+            Flag concretely if any of these appear in the diff:
+            - Secrets or API keys in committed files (**never approve**)
+            - DB queries that do NOT scope to `userId` from the Clerk server session (A01)
+            - User input reaching the DB or Claude API without Zod validation (A03)
+            - Raw SQL with string interpolation (A03)
+            - `dangerouslySetInnerHTML` with user-controlled content (A03)
+            - `fetch` to user-controlled URLs without allowlist validation (A10 / SSRF)
+            - Prompt construction that doesn't wrap user JD/resume content in `<data>` delimiters (A03 prompt injection)
+            - API routes importing `getAuth` / `getCurrentUser` directly from `@clerk/nextjs/server` instead of `src/lib/auth` (A07)
+
+            ## Code quality & TDD
+
+            - Tests committed BEFORE implementation (RED → GREEN → REFACTOR per CLAUDE.md)
+            - Unit tests mock external deps; integration tests hit a real DB
+            - Coverage targets: 70% overall / 90% on `src/profile/` / 100% on auth-core
+
+            ## How to deliver feedback
+
+            - Use `gh pr comment` for a single top-level summary comment.
+            - Use `mcp__github_inline_comment__create_inline_comment` (with
+              `confirmed: true`) for line-specific issues — cap at ~5 inline
+              comments so the review stays skimmable.
+            - Only post GitHub comments — do NOT return review text as messages.
+            - Lead with what is good; be specific and actionable; avoid nitpicks.
+            - This is an **advisory** review; do not block the PR.
+
+          claude_args: |
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"

--- a/README.md
+++ b/README.md
@@ -76,19 +76,19 @@ graph TD
 
 ## Tech Stack
 
-| Layer      | Technology                      | Notes                                              |
-|------------|---------------------------------|----------------------------------------------------|
-| Framework  | Next.js 15 (App Router)         | Full-stack, Vercel-native, RSC support             |
-| Database   | PostgreSQL via Neon              | Serverless-friendly, Vercel integration            |
-| ORM        | Prisma 7 (driver adapters)      | Type-safe queries, migration history               |
-| Auth       | Clerk (`@clerk/nextjs` ^7)      | Managed auth, Next.js middleware integration       |
-| AI         | OpenRouter / Claude API         | `openai` SDK pointed at OpenRouter; Anthropic core |
-| Validation | Zod ^3                          | Runtime schema validation on all API boundaries   |
-| Styling    | Tailwind CSS 4                  | Utility-first; Radix UI primitives                 |
-| PDF        | @react-pdf/renderer ^4          | Server-side PDF generation from React components  |
-| Testing    | Vitest ^3 + Playwright ^1.59    | Unit/integration + E2E                             |
-| Deploy     | Vercel                          | Preview deploys, env var management                |
-| CI/CD      | GitHub Actions                  | Lint, typecheck, tests, security, deploy           |
+| Layer      | Technology                   | Notes                                              |
+| ---------- | ---------------------------- | -------------------------------------------------- |
+| Framework  | Next.js 15 (App Router)      | Full-stack, Vercel-native, RSC support             |
+| Database   | PostgreSQL via Neon          | Serverless-friendly, Vercel integration            |
+| ORM        | Prisma 7 (driver adapters)   | Type-safe queries, migration history               |
+| Auth       | Clerk (`@clerk/nextjs` ^7)   | Managed auth, Next.js middleware integration       |
+| AI         | OpenRouter / Claude API      | `openai` SDK pointed at OpenRouter; Anthropic core |
+| Validation | Zod ^3                       | Runtime schema validation on all API boundaries    |
+| Styling    | Tailwind CSS 4               | Utility-first; Radix UI primitives                 |
+| PDF        | @react-pdf/renderer ^4       | Server-side PDF generation from React components   |
+| Testing    | Vitest ^3 + Playwright ^1.59 | Unit/integration + E2E                             |
+| Deploy     | Vercel                       | Preview deploys, env var management                |
+| CI/CD      | GitHub Actions               | Lint, typecheck, tests, security, deploy           |
 
 ---
 
@@ -144,18 +144,18 @@ Open [http://localhost:3000](http://localhost:3000).
 
 ## Scripts
 
-| Command                 | Description                                              |
-|-------------------------|----------------------------------------------------------|
-| `npm run dev`           | Start Next.js dev server                                 |
-| `npm run build`         | `prisma generate` + `next build`                         |
-| `npm run lint`          | ESLint via `next lint`                                   |
-| `npm test`              | Vitest unit tests (`vitest run`)                         |
-| `npm run test:watch`    | Vitest in watch mode                                     |
+| Command                    | Description                                                        |
+| -------------------------- | ------------------------------------------------------------------ |
+| `npm run dev`              | Start Next.js dev server                                           |
+| `npm run build`            | `prisma generate` + `next build`                                   |
+| `npm run lint`             | ESLint via `next lint`                                             |
+| `npm test`                 | Vitest unit tests (`vitest run`)                                   |
+| `npm run test:watch`       | Vitest in watch mode                                               |
 | `npm run test:integration` | Integration tests against real DB (`vitest.integration.config.ts`) |
-| `npm run test:coverage` | Vitest with v8 coverage report                           |
-| `npm run db:migrate`    | `prisma migrate dev` — create and apply migrations       |
-| `npm run db:studio`     | Open Prisma Studio                                       |
-| `npm run format`        | Prettier format all files                                |
+| `npm run test:coverage`    | Vitest with v8 coverage report                                     |
+| `npm run db:migrate`       | `prisma migrate dev` — create and apply migrations                 |
+| `npm run db:studio`        | Open Prisma Studio                                                 |
+| `npm run format`           | Prettier format all files                                          |
 
 ---
 
@@ -174,12 +174,12 @@ Kill switch for commit hooks: `BYPASSHIRE_DISABLE_COMMIT_HOOKS=1`.
 
 ### MCP Servers (`.mcp.json`)
 
-| Server     | Package / Image                          | Purpose                                                   |
-|------------|------------------------------------------|-----------------------------------------------------------|
-| github     | `ghcr.io/github/github-mcp-server`       | Fetch repo metadata, file contents, and language stats    |
-| vercel     | `vercel-mcp-server` (npx)                | Check deployment status, inspect env vars, tail logs      |
-| stitch     | HTTP — `https://stitch.googleapis.com/mcp` | Google Stitch design services                           |
-| playwright | `@playwright/mcp` (npx)                  | Browser automation for E2E — navigate, click, fill, screenshot |
+| Server     | Package / Image                            | Purpose                                                        |
+| ---------- | ------------------------------------------ | -------------------------------------------------------------- |
+| github     | `ghcr.io/github/github-mcp-server`         | Fetch repo metadata, file contents, and language stats         |
+| vercel     | `vercel-mcp-server` (npx)                  | Check deployment status, inspect env vars, tail logs           |
+| stitch     | HTTP — `https://stitch.googleapis.com/mcp` | Google Stitch design services                                  |
+| playwright | `@playwright/mcp` (npx)                    | Browser automation for E2E — navigate, click, fill, screenshot |
 
 ### Agents (`.claude/agents/`)
 
@@ -199,6 +199,35 @@ Kill switch for commit hooks: `BYPASSHIRE_DISABLE_COMMIT_HOOKS=1`.
 ## Testing Strategy
 
 Unit and integration tests run with Vitest. Unit tests mock external dependencies; integration tests run against a real Neon database (using `DATABASE_URL_TEST` if set, falling back to `DATABASE_URL`). End-to-end tests use Playwright against a locally running Next.js dev server and cover the golden path: sign-in, profile upload, job description entry, resume tailoring, and PDF export. Coverage thresholds are enforced at **70% overall**, **90% on `src/profile/`**, and **100% on auth/core paths**. The `test-runner guard` hook prevents the Claude Code session from closing while any test is red. See `docs/testing-strategy.md` for full details.
+
+---
+
+## CI/CD Pipeline
+
+Every PR and every push to `main` runs through an 8-stage GitHub Actions pipeline. The build graph and AI review are defined in `.github/workflows/`.
+
+| #   | Stage                          | Workflow                       |   Blocks merge?   | Notes                                                                               |
+| --- | ------------------------------ | ------------------------------ | :---------------: | ----------------------------------------------------------------------------------- |
+| 1   | **Lint**                       | `ci.yml` / `lint`              |        Yes        | ESLint + Prettier                                                                   |
+| 2   | **Typecheck**                  | `ci.yml` / `typecheck`         |        Yes        | `tsc --noEmit`                                                                      |
+| 3   | **Unit tests + coverage**      | `ci.yml` / `unit-test`         |        Yes        | Vitest; coverage comment on PR                                                      |
+| 3b  | **Integration tests (Neon)**   | `ci.yml` / `integration-tests` |        Yes        | Skips gracefully when `DATABASE_URL_TEST` is unset                                  |
+| 4   | **Security scan**              | `ci.yml` / `security`          |        Yes        | `npm audit` (fail on high/critical) + GitHub CodeQL (SAST)                          |
+| 5   | **Build**                      | `ci.yml` / `build`             |        Yes        | `npm run build` (Prisma generate + Next build)                                      |
+| 6   | **AI PR review**               | `claude-review.yml`            | **No (advisory)** | `anthropics/claude-code-action@v1` posts a C.L.E.A.R. + security DoD review comment |
+| 7   | **E2E (Playwright)**           | `ci.yml` / `e2e`               |        Yes        | Chromium against `next dev` with `DEV_AUTH_BYPASS=1`                                |
+| 8   | **Preview deploy (Vercel)**    | `ci.yml` / `deploy-preview`    |        No         | PRs only; posts preview URL as a PR comment                                         |
+| 8   | **Production deploy (Vercel)** | `ci.yml` / `deploy-production` |        n/a        | `main` pushes only, after E2E passes                                                |
+
+### AI PR Review setup
+
+Stage 6 uses a Claude Code subscription OAuth token so no per-PR API billing is required. To provision:
+
+1. Run `claude setup-token` locally and copy the long-lived token.
+2. Add it as a GitHub Actions secret named `CLAUDE_CODE_OAUTH_TOKEN` (Repo → Settings → Secrets and variables → Actions).
+3. Open any PR — the review comment appears within a minute or two of CI start.
+
+If the token is missing the stage fails red, but `continue-on-error: true` keeps the PR unblocked.
 
 ---
 
@@ -308,10 +337,10 @@ open http://localhost:3000/tailor
 
 ## Team
 
-| Name          | GitHub                                                  | Role            |
-|---------------|---------------------------------------------------------|-----------------|
-| Lipeipei Sun  | [@sunlipeipei](https://github.com/sunlipeipei)          | Full-stack       |
-| Dako          | [@dako7777777](https://github.com/dako7777777)          | Full-stack       |
+| Name         | GitHub                                         | Role       |
+| ------------ | ---------------------------------------------- | ---------- |
+| Lipeipei Sun | [@sunlipeipei](https://github.com/sunlipeipei) | Full-stack |
+| Dako         | [@dako7777777](https://github.com/dako7777777) | Full-stack |
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds **Stage 6 AI PR review** to the pipeline via a new standalone workflow (`.github/workflows/claude-review.yml`). Runs `anthropics/claude-code-action@v1` on every PR and posts a C.L.E.A.R. + security-DoD review comment.
- **Advisory** — `continue-on-error: true` ensures an Anthropic outage or a missing OAuth token never blocks merge.
- Documents the full 8-stage pipeline in `README.md` with a stage-by-stage table (including this workflow as Stage 6).

## Linked issue

Closes #24

The other items in #24 are handled elsewhere:
- Gitleaks pre-commit + security sub-agent → **#25** (S2-2)
- Vercel preview/prod deploy → already wired in `ci.yml`, deployment validation is owned by @sunlipeipei

---

## C.L.E.A.R. self-review

| Dimension | Criterion | Status | Author note |
|-----------|-----------|--------|-------------|
| **C**oncise | PR is focused on one concern | - [x] | Only adds the AI-review workflow + README docs |
| **L**inked | Ties back to a GitHub issue or spec section | - [x] | Closes #24 |
| **E**xplicit | All acceptance criteria from the issue are checked off below | - [x] | See AC section |
| **A**ctionable | Reviewer comment in the PR description says where to start reading | - [x] | Start at `.github/workflows/claude-review.yml` |
| **R**eviewable | Diff is under ~400 lines | - [x] | 149 insertions, 34 deletions |

---

## AI disclosure

- % AI-generated (code): ~90% (workflow + README table authored by Claude Code; human reviewed)
- Primary tool / model: Claude Code (Opus 4.7)
- Human review applied: - [x] yes — action schema verified via raw `action.yml` fetch; advisory-mode choice discussed with author before implementation
- AI-generated copy in user-facing strings: - [ ] no

---

## Acceptance criteria from #24

- [x] **Stage 4:** Playwright E2E tests run in CI *(already in `ci.yml`)*
- [x] **Stage 5:** `npm audit` security scan *(already in `ci.yml`, fails on high/critical)*
- [x] **Stage 6: AI PR review** *(this PR — `claude-review.yml`)*
- [x] **Stage 7:** Vercel preview deploy *(already in `ci.yml`)*
- [x] **Stage 8:** Production deploy to Vercel on merge to `main` *(already in `ci.yml`)*
- [x] Production URL documented in README *(placeholder "TBD" — @sunlipeipei will fill in once Vercel is live)*

---

## Test plan

- [ ] CI green on this PR — all 8 stages; Stage 6 (AI review) posts a comment within ~2 min of opening
- [ ] `npm run build` passes
- [ ] `npm run lint` passes
- [ ] Prettier check passes
- [ ] Confirm `CLAUDE_CODE_OAUTH_TOKEN` secret is set in repo (already done by author)

---

## Security DoD

- [x] No secrets or API keys committed (workflow reads `${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}`)
- [x] No user input validation impact (workflow changes only)
- [x] No DB query changes
- [x] No `dangerouslySetInnerHTML`
- [x] No raw SQL
- [x] No external URL fetches
- [x] `npm audit` passes

---

## Deployment notes

One-time secret provisioning required for Stage 6 to produce output:

1. Locally: `claude setup-token` → copy token
2. Repo Settings → Secrets and variables → Actions → add `CLAUDE_CODE_OAUTH_TOKEN`

If the secret is missing, the job fails red but `continue-on-error: true` keeps the PR unblocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)