### PR TITLE
feat(#25): Gitleaks pre-commit + CI gate + security-reviewer sub-agent

### DIFF
--- a/.claude/agents/security-reviewer.md
+++ b/.claude/agents/security-reviewer.md
@@ -1,0 +1,150 @@
+---
+name: security-reviewer
+description: BypassHire security reviewer scoped to OWASP Top 10 and project security policy. Use on every PR that touches auth, API routes, DB queries, external fetches, Claude API prompts, or user-facing rendering. MUST BE USED before merging anything in src/lib/auth/, app/api/, src/profile/, or any file that calls the Claude SDK.
+tools: ['Read', 'Grep', 'Glob', 'Bash']
+model: sonnet
+---
+
+You are a security reviewer for BypassHire. Your job is to catch OWASP Top 10 violations and project-specific security-policy violations before they ship.
+
+## Ground Truth
+
+Your reference documents in this repo:
+
+- `docs/security.md` — OWASP Top 10 mapping + Security DoD
+- `CLAUDE.md` — enforced conventions (TDD, Zod, userId scoping, no auto-submit)
+- `.github/PULL_REQUEST_TEMPLATE.md` — Security DoD checklist every PR must satisfy
+
+When your findings conflict with the code, cite the document line that the code violates.
+
+## Review Process
+
+1. **Gather diff** — Run `git diff --merge-base origin/main` (or `git diff --staged` if no PR base). If empty, run `git log --oneline -5` and `git show --stat HEAD`.
+2. **Classify changed files** by risk surface:
+   - `src/lib/auth/**`, `middleware.ts` — **auth boundary**
+   - `app/api/**` — **API surface**
+   - `src/profile/**`, `prisma/**` — **data boundary**
+   - `**/*claude*`, `**/*anthropic*` — **AI prompt surface**
+   - `app/**/page.tsx`, `app/**/*.tsx` — **render surface**
+   - `package.json`, `package-lock.json` — **supply chain**
+3. **Walk the checklist** for each touched surface (below). Only report findings you are >80% sure are real issues.
+4. **Report** using the output format at the bottom.
+
+## Checklist by OWASP Category
+
+### A01: Broken Access Control — CRITICAL
+
+- Every DB query must scope to the server-side `userId` from `auth()` / `getCurrentUser()`
+- `userId` must **never** come from request body, query string, or URL params
+- API routes must call auth **before** any DB operation
+- Cross-user access must be prevented by FK + integration test
+
+```typescript
+// BAD: userId from request body
+const { userId } = await req.json();
+await prisma.profile.findUnique({ where: { userId } });
+
+// GOOD: userId from session
+const { userId } = await auth();
+if (!userId) return new Response('Unauthorized', { status: 401 });
+await prisma.profile.findUnique({ where: { userId } });
+```
+
+### A02: Cryptographic Failures / Secret Exposure — CRITICAL
+
+- No secrets in source, tests, or fixtures — check diff for `sk-`, `clerk_`, `whsec_`, connection strings, API keys
+- `.env` must never be staged
+- Never log full request bodies (PII) or raw Claude prompts/responses
+- `DATABASE_URL` must include `sslmode=require` for Neon
+
+### A03: Injection — CRITICAL
+
+- **SQL:** No raw SQL with user input. `prisma.$queryRaw` with `${}` interpolation is a bug. Use `Prisma.sql` tagged templates or parameterized queries.
+- **Prompt injection:** Job descriptions and other user-supplied strings fed to Claude must be wrapped in clear delimiters (e.g., `<job_description>...</job_description>`) with a system instruction that the content is data, not instructions.
+- **Zod:** Every API route and every `JSON.parse` from the DB must go through Zod before use.
+
+### A04: Insecure Design — CRITICAL (product requirement)
+
+- Phase 3 auto-fill **must never auto-submit** — FR-3.5. Any form-submission code without explicit user confirmation is a block-merge finding.
+
+### A05: Security Misconfiguration — HIGH
+
+- No hardcoded credentials (including in tests — use env vars or mocks)
+- Middleware auth must cover `/dashboard/**` and `/api/**`
+- No CORS wildcards on authenticated endpoints
+- `dangerouslySetInnerHTML` with user-controlled content is a block-merge finding
+
+### A06: Vulnerable Components — HIGH
+
+- New deps added: check they are actively maintained, no known CVEs
+- `npm audit --audit-level=high` must pass (CI enforces this)
+
+### A07: Identification and Authentication Failures — CRITICAL
+
+- Import auth helpers from `src/lib/auth` only, not directly from `@clerk/nextjs/server` (ESLint enforces; flag if bypassed)
+- Never trust `userId` from the client
+- Session checks on every protected route — no "optional" auth in API routes that mutate state
+
+### A08: Software and Data Integrity Failures — HIGH
+
+- DB-stored JSON must be re-validated with Zod `safeParse()` on read (see `profileRepository.ts`)
+- `ProfileValidationError` pattern: throw, don't silently pass corrupt data to the UI
+
+### A09: Logging and Monitoring — MEDIUM
+
+- Log auth events and Claude API call metadata (model, tokens) — never full prompts/responses/PII
+- No `console.log(user)` or `console.log(profile)` in production paths
+
+### A10: SSRF — HIGH
+
+- Any `fetch(url)` where `url` comes from user input must validate against an allowlist
+- GitHub repo URLs must match `^https://github\.com/[a-zA-Z0-9_.-]+/[a-zA-Z0-9_.-]+$`
+- Prefer the GitHub MCP server over direct `fetch()` for GitHub calls
+
+## BypassHire-Specific Rules
+
+In addition to OWASP, check:
+
+- **No raw Anthropic SDK import** in route handlers — go through the project's Claude wrapper so prompt-injection delimiters and logging are consistent
+- **No `.env.local` or `.env.production`** ever staged — only `.env.example` is allowed
+- **Pre-commit bypass** (`--no-verify` in scripts, docs, or CI) is a block-merge finding unless explicitly justified in the PR description
+
+## Confidence-Based Filtering
+
+- Only report issues you are >80% sure are real
+- Skip issues in unchanged code unless they are CRITICAL
+- Consolidate similar findings (e.g., "4 API routes missing auth" as one entry with a file list)
+
+## Output Format
+
+```
+[CRITICAL] Missing userId scoping on profile write
+File: app/api/profile/route.ts:34
+Issue: userId read from request body (`body.userId`) instead of `auth()`. This allows
+       User A to overwrite User B's profile by sending B's userId.
+Fix:   Remove `userId` from the Zod schema and read it from `await auth()` instead.
+Docs:  docs/security.md §A01
+```
+
+Every review ends with:
+
+```
+## Security Review Summary
+
+| OWASP / Category | Severity | Count |
+|------------------|----------|-------|
+| A01 Access Ctrl  | CRITICAL | 1     |
+| A03 Injection    | HIGH     | 0     |
+| A07 Auth         | CRITICAL | 0     |
+| BypassHire       | HIGH     | 1     |
+
+Verdict: BLOCK — 1 CRITICAL must be resolved before merge.
+```
+
+## Approval Criteria
+
+- **Approve:** No CRITICAL, zero HIGH on auth/API/data surfaces
+- **Warn:** HIGH findings outside auth/API/data surfaces
+- **Block:** Any CRITICAL, any auto-submit path, any secret in source, any missing userId scoping, any unvalidated external fetch
+
+If the diff touches none of the risk surfaces listed in step 2, report `No security-sensitive changes detected` and exit.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,9 +170,10 @@ jobs:
         run: echo "DATABASE_URL_TEST secret is not set — integration tests skipped. Provision a Neon branch and add the secret to activate this tier."
 
   # ────────────────────────────────────────────────────────────────────────────
-  # Stage 4: Security — npm audit + GitHub CodeQL
-  # Fails the build on high or critical npm vulnerabilities.
-  # CodeQL results appear in the Security tab → Code scanning alerts.
+  # Stage 4: Security — gitleaks + npm audit + GitHub CodeQL
+  # Fails the build on committed secrets, high/critical npm vulnerabilities,
+  # or CodeQL findings. CodeQL results appear in the Security tab → Code
+  # scanning alerts.
   # ────────────────────────────────────────────────────────────────────────────
   security:
     name: Security Scan
@@ -185,6 +186,15 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Gitleaks needs full history to scan commits on PR branches.
+          fetch-depth: 0
+
+      - name: Gitleaks secret scan
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_CONFIG: .gitleaks.toml
 
       - uses: actions/setup-node@v4
         with:

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,20 @@
+title = "BypassHire Gitleaks Config"
+
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Paths and patterns that are safe to include"
+paths = [
+  '''\.env\.example$''',
+  '''(?i)\.gitleaks\.toml$''',
+  '''package-lock\.json$''',
+  '''docs/security\.md$''',
+]
+
+regexes = [
+  '''sk-[a-z]{3}\.\.\.''',
+  '''placeholder''',
+  '''postgresql://postgres:postgres@localhost''',
+  '''postgresql://placeholder:placeholder@localhost''',
+]

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,8 @@
+if ! command -v gitleaks >/dev/null 2>&1; then
+  echo "[pre-commit] gitleaks not installed — skipping secret scan."
+  echo "[pre-commit] Install with: brew install gitleaks"
+  echo "[pre-commit] CI will still block secrets via the security job."
+  exit 0
+fi
+
+gitleaks protect --staged --redact --verbose --config .gitleaks.toml

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,9 +101,9 @@ Two MCP servers are configured in `.mcp.json` at the repo root:
 
 ## Claude Code Features in Use
 
-- **Hooks:** PostToolUse lint-on-edit + Stop test-runner (see Issue #20); PostToolUse commit-signal (tests) + commit-signal (tasks) in `.claude/hooks/`
+- **Hooks:** PostToolUse lint-on-edit + Stop test-runner (see Issue #20); PostToolUse commit-signal (tests) + commit-signal (tasks) in `.claude/hooks/`; pre-commit gitleaks via `.husky/pre-commit` (see Issue #25)
 - **MCP:** GitHub, Vercel, Stitch, and Playwright MCP servers via `.mcp.json` (see Issue #21)
-- **Agents:** `.claude/agents/` — architect, planner, tdd-guide, code-reviewer, build-error-resolver, e2e-runner
+- **Agents:** `.claude/agents/` — architect, planner, tdd-guide, code-reviewer, security-reviewer, build-error-resolver, e2e-runner
 - **Skills:** `.claude/skills/` — architecture-decision-records, coding-standards, backend-patterns, e2e-testing, tdd-workflow, verification-loop, fix-issue
 
 ---

--- a/README.md
+++ b/README.md
@@ -76,19 +76,19 @@ graph TD
 
 ## Tech Stack
 
-| Layer      | Technology                      | Notes                                              |
-|------------|---------------------------------|----------------------------------------------------|
-| Framework  | Next.js 15 (App Router)         | Full-stack, Vercel-native, RSC support             |
-| Database   | PostgreSQL via Neon              | Serverless-friendly, Vercel integration            |
-| ORM        | Prisma 7 (driver adapters)      | Type-safe queries, migration history               |
-| Auth       | Clerk (`@clerk/nextjs` ^7)      | Managed auth, Next.js middleware integration       |
-| AI         | OpenRouter / Claude API         | `openai` SDK pointed at OpenRouter; Anthropic core |
-| Validation | Zod ^3                          | Runtime schema validation on all API boundaries   |
-| Styling    | Tailwind CSS 4                  | Utility-first; Radix UI primitives                 |
-| PDF        | @react-pdf/renderer ^4          | Server-side PDF generation from React components  |
-| Testing    | Vitest ^3 + Playwright ^1.59    | Unit/integration + E2E                             |
-| Deploy     | Vercel                          | Preview deploys, env var management                |
-| CI/CD      | GitHub Actions                  | Lint, typecheck, tests, security, deploy           |
+| Layer      | Technology                   | Notes                                              |
+| ---------- | ---------------------------- | -------------------------------------------------- |
+| Framework  | Next.js 15 (App Router)      | Full-stack, Vercel-native, RSC support             |
+| Database   | PostgreSQL via Neon          | Serverless-friendly, Vercel integration            |
+| ORM        | Prisma 7 (driver adapters)   | Type-safe queries, migration history               |
+| Auth       | Clerk (`@clerk/nextjs` ^7)   | Managed auth, Next.js middleware integration       |
+| AI         | OpenRouter / Claude API      | `openai` SDK pointed at OpenRouter; Anthropic core |
+| Validation | Zod ^3                       | Runtime schema validation on all API boundaries    |
+| Styling    | Tailwind CSS 4               | Utility-first; Radix UI primitives                 |
+| PDF        | @react-pdf/renderer ^4       | Server-side PDF generation from React components   |
+| Testing    | Vitest ^3 + Playwright ^1.59 | Unit/integration + E2E                             |
+| Deploy     | Vercel                       | Preview deploys, env var management                |
+| CI/CD      | GitHub Actions               | Lint, typecheck, tests, security, deploy           |
 
 ---
 
@@ -144,18 +144,18 @@ Open [http://localhost:3000](http://localhost:3000).
 
 ## Scripts
 
-| Command                 | Description                                              |
-|-------------------------|----------------------------------------------------------|
-| `npm run dev`           | Start Next.js dev server                                 |
-| `npm run build`         | `prisma generate` + `next build`                         |
-| `npm run lint`          | ESLint via `next lint`                                   |
-| `npm test`              | Vitest unit tests (`vitest run`)                         |
-| `npm run test:watch`    | Vitest in watch mode                                     |
+| Command                    | Description                                                        |
+| -------------------------- | ------------------------------------------------------------------ |
+| `npm run dev`              | Start Next.js dev server                                           |
+| `npm run build`            | `prisma generate` + `next build`                                   |
+| `npm run lint`             | ESLint via `next lint`                                             |
+| `npm test`                 | Vitest unit tests (`vitest run`)                                   |
+| `npm run test:watch`       | Vitest in watch mode                                               |
 | `npm run test:integration` | Integration tests against real DB (`vitest.integration.config.ts`) |
-| `npm run test:coverage` | Vitest with v8 coverage report                           |
-| `npm run db:migrate`    | `prisma migrate dev` — create and apply migrations       |
-| `npm run db:studio`     | Open Prisma Studio                                       |
-| `npm run format`        | Prettier format all files                                |
+| `npm run test:coverage`    | Vitest with v8 coverage report                                     |
+| `npm run db:migrate`       | `prisma migrate dev` — create and apply migrations                 |
+| `npm run db:studio`        | Open Prisma Studio                                                 |
+| `npm run format`           | Prettier format all files                                          |
 
 ---
 
@@ -174,12 +174,12 @@ Kill switch for commit hooks: `BYPASSHIRE_DISABLE_COMMIT_HOOKS=1`.
 
 ### MCP Servers (`.mcp.json`)
 
-| Server     | Package / Image                          | Purpose                                                   |
-|------------|------------------------------------------|-----------------------------------------------------------|
-| github     | `ghcr.io/github/github-mcp-server`       | Fetch repo metadata, file contents, and language stats    |
-| vercel     | `vercel-mcp-server` (npx)                | Check deployment status, inspect env vars, tail logs      |
-| stitch     | HTTP — `https://stitch.googleapis.com/mcp` | Google Stitch design services                           |
-| playwright | `@playwright/mcp` (npx)                  | Browser automation for E2E — navigate, click, fill, screenshot |
+| Server     | Package / Image                            | Purpose                                                        |
+| ---------- | ------------------------------------------ | -------------------------------------------------------------- |
+| github     | `ghcr.io/github/github-mcp-server`         | Fetch repo metadata, file contents, and language stats         |
+| vercel     | `vercel-mcp-server` (npx)                  | Check deployment status, inspect env vars, tail logs           |
+| stitch     | HTTP — `https://stitch.googleapis.com/mcp` | Google Stitch design services                                  |
+| playwright | `@playwright/mcp` (npx)                    | Browser automation for E2E — navigate, click, fill, screenshot |
 
 ### Agents (`.claude/agents/`)
 
@@ -308,10 +308,10 @@ open http://localhost:3000/tailor
 
 ## Team
 
-| Name          | GitHub                                                  | Role            |
-|---------------|---------------------------------------------------------|-----------------|
-| Lipeipei Sun  | [@sunlipeipei](https://github.com/sunlipeipei)          | Full-stack       |
-| Dako          | [@dako7777777](https://github.com/dako7777777)          | Full-stack       |
+| Name         | GitHub                                         | Role       |
+| ------------ | ---------------------------------------------- | ---------- |
+| Lipeipei Sun | [@sunlipeipei](https://github.com/sunlipeipei) | Full-stack |
+| Dako         | [@dako7777777](https://github.com/dako7777777) | Full-stack |
 
 ---
 

--- a/docs/final_delivery/INDEX.md
+++ b/docs/final_delivery/INDEX.md
@@ -24,12 +24,15 @@ This directory collects the final-submission deliverables. Some artifacts live a
 | Claude Code Mastery | Parallel worktree evidence (+ screenshots) | [`worktree-evidence.md`](./worktree-evidence.md) |
 | Claude Code Mastery | CLAUDE.md with @imports | [`/CLAUDE.md`](../../CLAUDE.md) |
 | Claude Code Mastery | Custom skills | [`/.claude/skills/`](../../.claude/skills/) |
-| Claude Code Mastery | Hooks configuration (4 hooks) | [`/.claude/settings.json`](../../.claude/settings.json) |
+| Claude Code Mastery | Hooks configuration (4 Claude hooks + gitleaks pre-commit) | [`/.claude/settings.json`](../../.claude/settings.json), [`/.husky/pre-commit`](../../.husky/pre-commit) |
 | Claude Code Mastery | MCP servers config | [`/CLAUDE.md` (MCP section)](../../CLAUDE.md) |
-| Claude Code Mastery | Custom agents | [`/.claude/agents/`](../../.claude/agents/) |
+| Claude Code Mastery | Custom agents (7: architect, planner, tdd-guide, code-reviewer, security-reviewer, build-error-resolver, e2e-runner) | [`/.claude/agents/`](../../.claude/agents/) |
 | CI/CD & Security | GitHub Actions CI | [`/.github/workflows/ci.yml`](../../.github/workflows/ci.yml) |
 | CI/CD & Security | PR template (C.L.E.A.R. + AI disclosure + security DoD) | [`/.github/PULL_REQUEST_TEMPLATE.md`](../../.github/PULL_REQUEST_TEMPLATE.md) |
 | CI/CD & Security | OWASP Top 10 doc | [`/docs/security.md`](../security.md) |
+| CI/CD & Security | Gitleaks pre-commit hook + config | [`/.husky/pre-commit`](../../.husky/pre-commit), [`/.gitleaks.toml`](../../.gitleaks.toml) |
+| CI/CD & Security | Gitleaks CI enforcement (security job) | [`/.github/workflows/ci.yml`](../../.github/workflows/ci.yml) |
+| CI/CD & Security | Security sub-agent (OWASP-scoped reviewer) | [`/.claude/agents/security-reviewer.md`](../../.claude/agents/security-reviewer.md) |
 | Testing & TDD | Implementation plan with 3 RED→GREEN pairs cited | [`/docs/phase_1-2/implementation-plan.md`](../phase_1-2/implementation-plan.md) |
 | Application Quality | Architecture doc | [`/docs/architecture.md`](../architecture.md) |
 | Application Quality | Product requirements (PRD) | [`/docs/PRD_Resume_Refine_AutoFill_Tool.md`](../PRD_Resume_Refine_AutoFill_Tool.md) |
@@ -58,9 +61,12 @@ These are tracked in GitHub. They are not documentation artifacts, but they gate
 | Issue | Summary | Rubric impact |
 |---|---|---|
 | #24 | Complete CI/CD: E2E + security scan + AI review + Vercel prod deploy | CI/CD & Production (35 pts) |
-| #25 | Gitleaks pre-commit + security sub-agent (PR template portion done — this INDEX links it) | Security gates |
 | #29 | 2+ Writer/Reviewer PRs w/ C.L.E.A.R. + AI disclosure | Claude Code Mastery |
 | #63 | Rubric evidence checklist (grader-facing) | Documentation |
+
+### Resolved after sprint close
+
+- **#25** — Gitleaks pre-commit + security sub-agent. Shipped on `worktree-issue-25-security-gates`: `.husky/pre-commit` (advisory local hook), `.gitleaks.toml` (rules + allowlist), `gitleaks/gitleaks-action@v2` step in the CI `security` job (enforced), `.claude/agents/security-reviewer.md` (OWASP-scoped sub-agent), PR template security DoD already on main. Stretch not shipped: headless Claude Code agent run in CI — deferred; local `/agents security-reviewer` covers the review workflow.
 
 ---
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -17,7 +17,7 @@
 
 - `DATABASE_URL`, `CLERK_SECRET_KEY`, `ANTHROPIC_API_KEY` must **never** be committed
 - `.env` is in `.gitignore`; use `.env.example` with placeholder values
-- Gitleaks pre-commit hook will be added in Issue #25 (S2-2) to block accidental commits
+- Gitleaks pre-commit hook (`.husky/pre-commit`) and CI `security` job (`gitleaks/gitleaks-action@v2`) block committed secrets — Issue #25 (S2-2). Config: `.gitleaks.toml`.
 - Never log full request bodies that may contain resume content (PII)
 - Neon connection requires `sslmode=require` — enforced in `DATABASE_URL`
 
@@ -104,8 +104,15 @@ Every PR must confirm:
 
 ---
 
-## Future Security Gates (Issue #25 — S2-2)
+## Security Gates (Issue #25 — S2-2)
 
-- Pre-commit: Gitleaks secrets detection
-- CI: Automated security sub-agent PR review
-- CI: SAST scan
+Shipped:
+
+- **Pre-commit:** Gitleaks secrets detection via `.husky/pre-commit` (local, best-effort — exits 0 if gitleaks is not installed so contributors without the binary aren't blocked). Config: `.gitleaks.toml` with `useDefault = true` plus an allowlist for `.env.example`, `package-lock.json`, and documentation samples.
+- **CI:** Gitleaks action (`gitleaks/gitleaks-action@v2`) runs on every PR in the `security` job — this is the enforced gate; the pre-commit hook is advisory.
+- **CI:** CodeQL SAST scan in the same `security` job (results in GitHub Security → Code scanning alerts).
+- **Sub-agent:** `.claude/agents/security-reviewer.md` — OWASP-scoped reviewer invoked on PRs that touch auth, API routes, DB queries, external fetches, Claude prompts, or user-facing rendering.
+
+Not shipped (stretch):
+
+- Automated security-sub-agent run in CI via a GitHub Action that calls Claude Code headlessly on PRs. Deferred; local invocation via `/agents security-reviewer` is the workflow for now.


### PR DESCRIPTION
Closes #25.

## Summary

- `.husky/pre-commit` — advisory gitleaks scan on staged files (exits 0 if binary not installed so contributors without gitleaks aren't blocked)
- `.gitleaks.toml` — default ruleset + allowlist for `.env.example`, lockfile, `docs/security.md` (contains sample secrets in code blocks), and placeholder connection strings
- `.github/workflows/ci.yml` — `gitleaks/gitleaks-action@v2` step added to the `security` job with `fetch-depth: 0`. This is the enforced gate; pre-commit is advisory.
- `.claude/agents/security-reviewer.md` — OWASP-scoped sub-agent keyed to `docs/security.md` (A01 userId scoping, A03 prompt-injection delimiters, A07 auth import rules, BypassHire no-auto-submit rule)
- `CLAUDE.md`, `docs/security.md`, `docs/final_delivery/INDEX.md` — updated to reflect shipped artifacts; `#25` moved to a new "Resolved after sprint close" subsection

Stretch not shipped: headless Claude Code agent run in CI. Documented as deferred in `docs/security.md`; local `/agents security-reviewer` invocation covers the review workflow.

## C.L.E.A.R. review (Writer: Claude Opus 4.7; Reviewer: Dako)

- **Context** — Issue #25 is the S2-2 security-gates story. Pre-sprint state had only the PR-template Security DoD; the gitleaks hook, CI scan, and sub-agent were unshipped. `docs/security.md:107` explicitly listed these as "Future Security Gates."
- **Logic** — Two-layer gate: advisory local hook + enforced CI action. The pre-commit hook intentionally does not block when gitleaks is missing — prevents onboarding friction; CI is the source of truth. `fetch-depth: 0` is required by `gitleaks-action@v2` so it can diff against the PR base.
- **Edge cases** — `.gitleaks.toml` allowlist: `.env.example` (placeholder values), `package-lock.json` (noisy false positives in integrity hashes), `docs/security.md` (contains OWASP-example secret strings in fenced code blocks that would otherwise trip rules).
- **Alternatives** — (a) A GitHub Action that runs Claude Code headlessly on each PR to invoke `security-reviewer` — out-of-scope for the deadline; requires Anthropic API key in repo secrets + rate-limit handling. (b) Running gitleaks in a separate job — rejected; keeping it in the existing `security` job reduces runner count.
- **Risks** — Merge conflict likely with PR #24 (Dako's CI/CD E2E work) on `.github/workflows/ci.yml` around the `security` job. Small conflict, resolves cleanly.

## AI disclosure

- **Authorship:** Claude Opus 4.7 wrote the hook, gitleaks config, sub-agent markdown, ci.yml diff, and doc updates in a single session on branch `worktree-issue-25-security-gates`.
- **Human review:** Dako reviewed the plan before implementation and will review the diff before merge.
- **Tool use:** No Claude API calls are invoked by this PR at runtime. The sub-agent is a markdown spec loaded by Claude Code when a developer locally runs `/agents security-reviewer`.

## Security DoD

- [x] No secrets or API keys committed
- [x] All user input validated with Zod (N/A — no new user input paths)
- [x] DB queries scoped to authenticated `userId` (N/A — no DB changes)
- [x] No `dangerouslySetInnerHTML` with user-controlled content (N/A)
- [x] No raw SQL with string interpolation (N/A)
- [x] GitHub/external URLs validated before fetch (N/A)
- [x] `npm audit` passes with no high/critical issues — unchanged from main

## Test plan

- [x] `npm run format:check` passes (pre-push hook verified)
- [x] `npx tsc --noEmit` passes (pre-push hook verified)
- [ ] After merge: confirm CI `security` job runs the new gitleaks step and fails on a deliberate test commit containing a fake secret
- [ ] After merge: run `/agents security-reviewer` locally against a test branch that violates A01 to verify the sub-agent reports correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)